### PR TITLE
Fix several bugs with replace and replace around steps

### DIFF
--- a/.yarn/versions/339debfa.yml
+++ b/.yarn/versions/339debfa.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/prosemirror-suggest-changes": patch

--- a/demo/main.css
+++ b/demo/main.css
@@ -12,14 +12,16 @@
   max-width: 700px;
 }
 
-ins {
-  background-color: #7aea9f;
+ins,
+[data-node-insertion] {
+  background-color: #baffdf;
   color: #00973c;
 }
 
-del {
+del,
+[data-node-deletion] {
   color: #9f003e;
-  background-color: #ec779c;
+  background-color: #ffb7dc;
 }
 
 .menu {

--- a/src/findSuggestionMarkEnd.ts
+++ b/src/findSuggestionMarkEnd.ts
@@ -23,9 +23,14 @@ export function findSuggestionMarkEnd($pos: ResolvedPos, markType: MarkType) {
     // We're at the end of a node. We need to check
     // whether there's a matching deletion at the beginning
     // of the next node
-    const afterParentPos = $afterPos.after();
-    const $afterParentPos = $pos.doc.resolve(afterParentPos);
-    const nextParent = $afterParentPos.nodeAfter;
+    let afterParentPos = $afterPos.after();
+    let $afterParentPos = $pos.doc.resolve(afterParentPos);
+    let nextParent = $afterParentPos.nodeAfter;
+    while ($afterParentPos.depth > 0 && !nextParent) {
+      afterParentPos = $afterPos.after($afterParentPos.depth);
+      $afterParentPos = $pos.doc.resolve(afterParentPos);
+      nextParent = $afterParentPos.nodeAfter;
+    }
 
     let cousinStartPos = afterParentPos + 1;
     let cousin = nextParent?.firstChild;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -12,6 +12,7 @@ export const deletion: MarkSpec = {
       {
         "data-id": String(mark.attrs["id"]),
         "data-inline": String(inline),
+        ...(!inline && { style: "display: block" }),
       },
       0,
     ];
@@ -41,6 +42,7 @@ export const insertion: MarkSpec = {
       {
         "data-id": String(mark.attrs["id"]),
         "data-inline": String(inline),
+        ...(!inline && { style: "display: block" }),
       },
       0,
     ];


### PR DESCRIPTION
Properly handles list sink commands by treating them like
a replace of the current and previous list item with a
new list item containing the sinked list.

Properly handles arbitrary-depth textblocks with adjacent
marks with the same id. This means that deletions across
list items can now be applied correctly.

"Skips" deletes on zero-width spaces, to avoid having to
double-backspace at the end of a textblock with a zero-width
space.