### PR TITLE
Remove Extraneous Console Log

### DIFF
--- a/.yarn/versions/743897d8.yml
+++ b/.yarn/versions/743897d8.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/prosemirror-suggest-changes": patch

--- a/src/withSuggestChanges.ts
+++ b/src/withSuggestChanges.ts
@@ -223,6 +223,5 @@ export function withSuggestChanges(
         ? transformToSuggestionTransaction(tr, this.state)
         : tr;
     dispatch.call(this, transaction);
-    console.log(this.state);
   };
 }


### PR DESCRIPTION
The leftover `console.log` in the code floods the `Console` with unnecessary content. 

<img width="630" alt="Screenshot 2025-04-21 at 4 30 57 PM" src="https://github.com/user-attachments/assets/3c53cb02-2e99-4122-8d55-2438e6df1dab" />
