### PR TITLE
Fix various issues with zero-width space handling

### DIFF
--- a/.yarn/versions/d8e99d7c.yml
+++ b/.yarn/versions/d8e99d7c.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/prosemirror-suggest-changes": patch

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -75,6 +75,9 @@ function applySuggestionsToTransform(
     const insertionTo = insertionFrom + child.nodeSize;
     if (child.isInline) {
       tr.removeMark(insertionFrom, insertionTo, markTypeToApply);
+      if (child.text === "\u200B") {
+        tr.delete(insertionFrom, insertionTo);
+      }
     } else {
       tr.removeNodeMark(insertionFrom, markTypeToApply);
     }

--- a/src/replaceStep.ts
+++ b/src/replaceStep.ts
@@ -147,7 +147,10 @@ export function suggestReplaceStep(
     // that space. We'll join the marks later, and can use
     // the joined marks to find deletions across the block
     // boundary
-    if ($stepFrom.nodeBefore?.text?.endsWith("\u200B")) {
+    if (
+      $stepFrom.nodeBefore?.text?.endsWith("\u200B") &&
+      !$stepTo.nodeAfter?.text?.startsWith("\u200B")
+    ) {
       trackedTransaction.delete(stepFrom - 1, stepFrom);
       stepFrom--;
       stepTo--;
@@ -155,13 +158,12 @@ export function suggestReplaceStep(
       $stepTo = trackedTransaction.doc.resolve(stepTo);
     }
 
-    if ($stepTo.nodeAfter?.text?.startsWith("\u200B")) {
+    if (
+      $stepTo.nodeAfter?.text?.startsWith("\u200B") &&
+      !$stepFrom.nodeBefore?.text?.endsWith("\u200B")
+    ) {
       trackedTransaction.delete(stepTo, stepTo + 1);
     }
-
-    // TODO: Handle a user pressing the (forward) delete key
-    // at the very beginning of a text node that starts
-    // with a zero-width space
 
     // If the user is deleting exactly a zero-width space,
     // delete the space and also shift the range back by one,


### PR DESCRIPTION
Fixes #5.

Improves the checks that auto-delete zero-width spaces when deletion marks are merged. Also adds code to delete zero-width spaces when applying suggestions, and adds a custom keydown handler to skip them when using the arrow keys