### PR TITLE
Add support for y-prosemirror history

### DIFF
--- a/.yarn/versions/e73a8f71.yml
+++ b/.yarn/versions/e73a8f71.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/prosemirror-suggest-changes": patch

--- a/src/withSuggestChanges.ts
+++ b/src/withSuggestChanges.ts
@@ -219,6 +219,7 @@ export function withSuggestChanges(
       isSuggestChangesEnabled(this.state) &&
       !tr.getMeta("history$") &&
       !tr.getMeta("collab$") &&
+      !tr.getMeta("y-sync$")?.isUndoRedoOperation &&
       !("skip" in (tr.getMeta(suggestChangesKey) ?? {}))
         ? transformToSuggestionTransaction(tr, this.state)
         : tr;

--- a/src/withSuggestChanges.ts
+++ b/src/withSuggestChanges.ts
@@ -215,11 +215,17 @@ export function withSuggestChanges(
     };
 
   return function dispatchTransaction(this: EditorView, tr: Transaction) {
+    const ySyncMeta = (tr.getMeta("y-sync$") ?? {}) as {
+      isUndoRedoOperation?: boolean;
+      isChangeOrigin?: boolean;
+    };
+
     const transaction =
       isSuggestChangesEnabled(this.state) &&
       !tr.getMeta("history$") &&
       !tr.getMeta("collab$") &&
-      !tr.getMeta("y-sync$")?.isUndoRedoOperation &&
+      !ySyncMeta.isUndoRedoOperation &&
+      !ySyncMeta.isChangeOrigin &&
       !("skip" in (tr.getMeta(suggestChangesKey) ?? {}))
         ? transformToSuggestionTransaction(tr, this.state)
         : tr;


### PR DESCRIPTION
Hey @smoores-dev, thank you for your work on this package! Great work!

We're just starting to integrate it into our application, and we needed to add support for `y-prosemirror`'s custom undo/redo mechanism. Since prosemirror is often used in collaborative scenarios, this might be useful for other users of the library as well.