### PR TITLE
[BREAKING/PROPOSAL] Generate unique string ids

### DIFF
--- a/src/__tests__/addMarkStep.test.ts
+++ b/src/__tests__/addMarkStep.test.ts
@@ -33,14 +33,14 @@ describe("AddMarkStep", () => {
     assert(step instanceof AddMarkStep, "Could not create test AddMarkStep");
 
     const trackedTransaction = editorState.tr;
-    trackAddMarkStep(trackedTransaction, editorState, doc, step, [], 1);
+    trackAddMarkStep(trackedTransaction, editorState, doc, step, [], "1");
 
     const trackedState = editorState.apply(trackedTransaction);
 
     const expected = testBuilders.doc(
       testBuilders.paragraph(
-        testBuilders.deletion({ id: 1 }, "first"),
-        testBuilders.insertion({ id: 1 }, testBuilders.strong("first")),
+        testBuilders.deletion({ id: "1" }, "first"),
+        testBuilders.insertion({ id: "1" }, testBuilders.strong("first")),
         " paragraph",
       ),
       testBuilders.paragraph("second paragraph"),
@@ -55,7 +55,7 @@ describe("AddMarkStep", () => {
   it("should handle overlapping deletions", () => {
     const doc = testBuilders.doc(
       testBuilders.paragraph(
-        testBuilders.deletion({ id: 1 }, "<a>fi"),
+        testBuilders.deletion({ id: "1" }, "<a>fi"),
         "rst<b> paragraph",
       ),
       testBuilders.paragraph("second paragraph"),
@@ -77,14 +77,14 @@ describe("AddMarkStep", () => {
     assert(step instanceof AddMarkStep, "Could not create test AddMarkStep");
 
     const trackedTransaction = editorState.tr;
-    trackAddMarkStep(trackedTransaction, editorState, doc, step, [], 1);
+    trackAddMarkStep(trackedTransaction, editorState, doc, step, [], "1");
 
     const trackedState = editorState.apply(trackedTransaction);
 
     const expected = testBuilders.doc(
       testBuilders.paragraph(
-        testBuilders.deletion({ id: 1 }, "first"),
-        testBuilders.insertion({ id: 1 }, testBuilders.strong("rst")),
+        testBuilders.deletion({ id: "1" }, "first"),
+        testBuilders.insertion({ id: "1" }, testBuilders.strong("rst")),
         " paragraph",
       ),
       testBuilders.paragraph("second paragraph"),

--- a/src/addMarkStep.ts
+++ b/src/addMarkStep.ts
@@ -23,8 +23,8 @@ export function trackAddMarkStep(
   doc: Node,
   step: AddMarkStep,
   prevSteps: Step[],
-  suggestionId: number,
-) {
+  suggestionId: string,
+): boolean {
   const applied = step.apply(doc).doc;
   if (!applied) return false;
   const slice = applied.slice(step.from, step.to);

--- a/src/addNodeMarkStep.ts
+++ b/src/addNodeMarkStep.ts
@@ -16,8 +16,8 @@ export function trackAddNodeMarkStep(
   _doc: Node,
   step: AddNodeMarkStep,
   prevSteps: Step[],
-  suggestionId: number,
-) {
+  suggestionId: string,
+): boolean {
   const { modification } = state.schema.marks;
   if (!modification) {
     throw new Error(

--- a/src/attrStep.ts
+++ b/src/attrStep.ts
@@ -16,8 +16,8 @@ export function trackAttrStep(
   _doc: Node,
   step: AttrStep,
   prevSteps: Step[],
-  suggestionId: number,
-) {
+  suggestionId: string,
+): boolean {
   const { modification } = state.schema.marks;
   if (!modification) {
     throw new Error(

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -29,7 +29,7 @@ function applySuggestionsToTransform(
   tr: Transform,
   markTypeToApply: MarkType,
   markTypeToRevert: MarkType,
-  suggestionId?: number,
+  suggestionId?: string,
 ) {
   const toApplyIsInSet =
     suggestionId === undefined
@@ -119,7 +119,7 @@ function applyModificationsToTransform(
   node: Node,
   tr: Transform,
   dir: number,
-  suggestionId?: number,
+  suggestionId?: string,
 ) {
   const { modification } = node.type.schema.marks;
   if (!modification) {
@@ -227,7 +227,7 @@ export function applySuggestions(
  * The insertion mark and modification mark will be removed, and their
  * contents left in the doc.
  */
-export function applySuggestion(suggestionId: number): Command {
+export function applySuggestion(suggestionId: string): Command {
   return (state, dispatch) => {
     const { deletion, insertion } = state.schema.marks;
     if (!deletion) {
@@ -294,7 +294,7 @@ export function revertSuggestions(
  * The deletion mark will be removed, and their contents left in the doc.
  * Modifications tracked in modification marks will be reverted.
  */
-export function revertSuggestion(suggestionId: number): Command {
+export function revertSuggestion(suggestionId: string): Command {
   return (state, dispatch) => {
     const { deletion, insertion } = state.schema.marks;
     if (!deletion) {
@@ -327,7 +327,7 @@ export function revertSuggestion(suggestionId: number): Command {
 /**
  * Command that updates the selection to cover an existing change.
  */
-export function selectSuggestion(suggestionId: number): Command {
+export function selectSuggestion(suggestionId: string): Command {
   return (state, dispatch) => {
     const { deletion, insertion, modification } = state.schema.marks;
     if (!deletion) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,9 @@ export {
   suggestChanges,
   suggestChangesKey,
   isSuggestChangesEnabled,
+  getSuggestChangesGenerateId,
+  type SuggestChangesOptions,
+  type SuggestChangesPluginState,
 } from "./plugin.js";
 
 export { withSuggestChanges } from "./withSuggestChanges.js";

--- a/src/removeMarkStep.ts
+++ b/src/removeMarkStep.ts
@@ -23,8 +23,8 @@ export function suggestRemoveMarkStep(
   doc: Node,
   step: RemoveMarkStep,
   prevSteps: Step[],
-  suggestionId: number,
-) {
+  suggestionId: string,
+): boolean {
   const applied = step.apply(doc).doc;
   if (!applied) return false;
   const slice = applied.slice(step.from, step.to);

--- a/src/removeNodeMarkStep.ts
+++ b/src/removeNodeMarkStep.ts
@@ -16,8 +16,8 @@ export function suggestRemoveNodeMarkStep(
   _doc: Node,
   step: RemoveNodeMarkStep,
   prevSteps: Step[],
-  suggestionId: number,
-) {
+  suggestionId: string,
+): boolean {
   const { modification } = state.schema.marks;
   if (!modification) {
     throw new Error(

--- a/src/replaceAroundStep.ts
+++ b/src/replaceAroundStep.ts
@@ -23,8 +23,8 @@ export function suggestReplaceAroundStep(
   doc: Node,
   step: ReplaceAroundStep,
   prevSteps: Step[],
-  suggestionId: number,
-) {
+  suggestionId: string,
+): boolean {
   const applied = step.apply(doc).doc;
   if (!applied) return false;
   const from = step.getMap().map(step.from, -1);

--- a/src/replaceStep.ts
+++ b/src/replaceStep.ts
@@ -45,7 +45,7 @@ export function suggestReplaceStep(
   doc: Node,
   step: ReplaceStep,
   prevSteps: Step[],
-  suggestionId: number,
+  suggestionId: string,
 ) {
   const { deletion, insertion } = state.schema.marks;
   if (!deletion) {
@@ -74,8 +74,8 @@ export function suggestReplaceStep(
     ) ?? null;
 
   const markId =
-    (markBefore?.attrs["id"] as number | undefined) ??
-    (markAfter?.attrs["id"] as number | undefined) ??
+    (markBefore?.attrs["id"] as string | undefined) ??
+    (markAfter?.attrs["id"] as string | undefined) ??
     suggestionId;
 
   const insertedRanges: { from: number; to: number }[] = [];

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -4,7 +4,7 @@ export const deletion: MarkSpec = {
   inclusive: false,
   excludes: "insertion modification deletion",
   attrs: {
-    id: { validate: "number" },
+    id: { validate: "string" },
   },
   toDOM(mark, inline) {
     return [
@@ -23,7 +23,7 @@ export const deletion: MarkSpec = {
       getAttrs(node) {
         if (!node.dataset["id"]) return false;
         return {
-          id: parseInt(node.dataset["id"], 10),
+          id: node.dataset["id"],
         };
       },
     },
@@ -34,7 +34,7 @@ export const insertion: MarkSpec = {
   inclusive: false,
   excludes: "deletion modification insertion",
   attrs: {
-    id: { validate: "number" },
+    id: { validate: "string" },
   },
   toDOM(mark, inline) {
     return [
@@ -53,7 +53,7 @@ export const insertion: MarkSpec = {
       getAttrs(node) {
         if (!node.dataset["id"]) return false;
         return {
-          id: parseInt(node.dataset["id"], 10),
+          id: node.dataset["id"],
         };
       },
     },
@@ -64,7 +64,7 @@ export const modification: MarkSpec = {
   inclusive: false,
   excludes: "deletion insertion",
   attrs: {
-    id: { validate: "number" },
+    id: { validate: "string" },
     type: { validate: "string" },
     attrName: { default: null, validate: "string|null" },
     previousValue: { default: null },
@@ -90,7 +90,7 @@ export const modification: MarkSpec = {
       getAttrs(node) {
         if (!node.dataset["id"]) return false;
         return {
-          id: parseInt(node.dataset["id"], 10),
+          id: node.dataset["id"],
           type: node.dataset["modType"],
           previousValue: node.dataset["modPrevVal"],
           newValue: node.dataset["modNewVal"],
@@ -102,7 +102,7 @@ export const modification: MarkSpec = {
       getAttrs(node) {
         if (!node.dataset["id"]) return false;
         return {
-          id: parseInt(node.dataset["id"], 10),
+          id: node.dataset["id"],
           type: node.dataset["modType"],
           previousValue: node.dataset["modPrevVal"],
         };

--- a/src/withSuggestChanges.ts
+++ b/src/withSuggestChanges.ts
@@ -19,7 +19,11 @@ import { suggestRemoveNodeMarkStep } from "./removeNodeMarkStep.js";
 import { suggestReplaceAroundStep } from "./replaceAroundStep.js";
 import { suggestReplaceStep } from "./replaceStep.js";
 import { type EditorView } from "prosemirror-view";
-import { isSuggestChangesEnabled, suggestChangesKey } from "./plugin.js";
+import {
+  isSuggestChangesEnabled,
+  getSuggestChangesGenerateId,
+  suggestChangesKey,
+} from "./plugin.js";
 
 type StepHandler<S extends Step> = (
   trackedTransaction: Transaction,
@@ -27,7 +31,7 @@ type StepHandler<S extends Step> = (
   doc: Node,
   step: S,
   prevSteps: Step[],
-  suggestionId: number,
+  suggestionId: string,
 ) => boolean;
 
 function getStepHandler<S extends Step>(step: S): StepHandler<S> {
@@ -115,23 +119,8 @@ export function transformToSuggestionTransaction(
     );
   }
 
-  // Find the highest change id in the document so far,
-  // and use that as the starting point for new changes
-  let suggestionId = 0;
-  originalTransaction.docs[0]?.descendants((node) => {
-    const mark = node.marks.find(
-      (mark) =>
-        mark.type === insertion ||
-        mark.type === deletion ||
-        mark.type === modification,
-    );
-    if (mark) {
-      suggestionId = Math.max(suggestionId, mark.attrs["id"] as number);
-      return false;
-    }
-    return true;
-  });
-  suggestionId++;
+  // Get the generateId function from the plugin state
+  const generateId = getSuggestChangesGenerateId(state);
 
   // Create a new transaction from scratch. The original transaction
   // is going to be dropped in favor of this one.
@@ -145,20 +134,18 @@ export function transformToSuggestionTransaction(
     const doc = originalTransaction.docs[i]!;
 
     const stepTracker = getStepHandler(step);
-    if (
-      stepTracker(
-        trackedTransaction,
-        state,
-        doc,
-        step,
-        originalTransaction.steps.slice(0, i),
-        suggestionId,
-      )
-    ) {
-      // If the suggestionId was used by one of the step handlers,
-      // increment it so that it's not reused.
-      suggestionId++;
-    }
+
+    // Generate a new unique ID for this step
+    const suggestionId = generateId();
+
+    stepTracker(
+      trackedTransaction,
+      state,
+      doc,
+      step,
+      originalTransaction.steps.slice(0, i),
+      suggestionId,
+    );
     continue;
   }
 


### PR DESCRIPTION
Hey @smoores-dev! 👋 

We're integrating prosemirror-suggest-changes in our application, and we needed to add support for persistent, unique string ids for suggestions so that we can tie additional metadata (e.g. author information, conversation threads) to them.

I'm opening this draft PR as a conversation on whether you'd be open to considering something like this in upstream. The current iteration is a breaking change from your existing schema (it changes the id type from `number` to `string`), so we would probably want to have a backwards compatible approach here.

Let me know your thoughts -- this current patch works well for us now, but I'm happy to do the additional work to make this mergeable if there's broad interest.
