### PR TITLE
replaceStep working across insertion ranges with multiple nodes

### DIFF
--- a/.yarn/versions/4a39fbbd.yml
+++ b/.yarn/versions/4a39fbbd.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/prosemirror-suggest-changes": patch

--- a/src/__tests__/replaceStep.test.ts
+++ b/src/__tests__/replaceStep.test.ts
@@ -770,7 +770,7 @@ describe("ReplaceStep", () => {
     originalTransaction.step(step);
 
     const trackedTransaction = editorState.tr;
-    suggestReplaceStep(trackedTransaction, editorState, doc, step, [], "1");
+    suggestReplaceStep(trackedTransaction, editorState, doc, step, [], 1);
 
     const trackedState = editorState.apply(trackedTransaction);
 

--- a/src/__tests__/replaceStep.test.ts
+++ b/src/__tests__/replaceStep.test.ts
@@ -736,4 +736,54 @@ describe("ReplaceStep", () => {
       `Expected ${trackedState.doc} to match ${expected}`,
     );
   });
+
+  it("should handle replacements over insertion ranges with multiple text segments", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        testBuilders.insertion({ id: "0" }, "before"),
+        testBuilders.insertion({ id: "0" }, "<a>plain"),
+        testBuilders.insertion({ id: "0" }, testBuilders.strong("bold")),
+        testBuilders.insertion({ id: "0" }, testBuilders.em("italic<b>both")),
+      ),
+    ) as TaggedNode;
+
+    // Replace content between <a> and <b> with same text but without marks
+    const step = replaceStep(
+      doc,
+      doc.tag["a"]!,
+      doc.tag["b"],
+      new Slice(
+        Fragment.from(testBuilders.schema.text("plainbolditalic")),
+        0,
+        0,
+      ),
+    ) as ReplaceStep | null;
+
+    assert(step, "Could not create test ReplaceStep");
+
+    const editorState = EditorState.create({
+      doc,
+      selection: TextSelection.atEnd(doc),
+    });
+
+    const originalTransaction = editorState.tr;
+    originalTransaction.step(step);
+
+    const trackedTransaction = editorState.tr;
+    suggestReplaceStep(trackedTransaction, editorState, doc, step, [], "1");
+
+    const trackedState = editorState.apply(trackedTransaction);
+
+    const expected = testBuilders.doc(
+      testBuilders.paragraph(
+        testBuilders.insertion({ id: "0" }, "beforeplainbolditalic"),
+        testBuilders.insertion({ id: "0" }, testBuilders.em("both")),
+      ),
+    );
+
+    assert(
+      eq(trackedState.doc, expected),
+      `Expected ${trackedState.doc} to match ${expected}`,
+    );
+  });
 });

--- a/src/replaceStep.ts
+++ b/src/replaceStep.ts
@@ -95,6 +95,9 @@ export function suggestReplaceStep(
   });
 
   // Delete the previously-inserted ranges for real
+  // ranges are reverted, applying them in this order saves rebasing
+  // since deletions won't affect earlier deletions
+  insertedRanges.reverse();
   for (const range of insertedRanges) {
     trackedTransaction.delete(range.from, range.to);
   }
@@ -211,6 +214,9 @@ export function suggestReplaceStep(
       },
     );
   }
+
+  // TODO: This could break if there's already a deletion-insertion-deletion-insertion combination
+  // This is the code that creates those combinations, doing this twice in a row could break it
 
   // Detect when a new mark directly abuts an existing mark with
   // a different id and merge them


### PR DESCRIPTION
During replaceSteps the deleted ranges were not correct ( rebase issue ), it caused errors when a replaceStep affected multiple inline nodes ( for example a range with different marks ).
Added test for proof.