### PR TITLE
Fix nested addMarkSteps inside insertions.

### DIFF
--- a/src/__tests__/addMarkStep.test.ts
+++ b/src/__tests__/addMarkStep.test.ts
@@ -95,4 +95,211 @@ describe("AddMarkStep", () => {
       `Expected ${trackedState.doc} to match ${expected}`,
     );
   });
+
+  it("should handle nested addMarkSteps with inner mark completely inside outer mark", () => {
+    // Starting document already has a suggestion change with strong mark applied
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "This ",
+        testBuilders.deletion({ id: 1 }, "is a test paragraph with"),
+        testBuilders.insertion(
+          { id: 1 },
+          testBuilders.strong("is a <b>test paragraph<c> with"),
+        ),
+        " content",
+      ),
+    ) as TaggedNode;
+
+    const editorState = EditorState.create({
+      doc,
+    });
+
+    // Add emphasis mark to a smaller range completely inside the existing strong mark (from 'b' to 'c')
+    const originalTransaction = editorState.tr;
+    originalTransaction.addMark(
+      doc.tag["b"]!,
+      doc.tag["c"]!,
+      testBuilders.schema.marks.em.create(),
+    );
+    const step = originalTransaction.steps[0];
+    assert(step instanceof AddMarkStep, "Could not create AddMarkStep");
+
+    // Apply the step with tracking
+    const trackedTransaction = editorState.tr;
+    trackAddMarkStep(trackedTransaction, editorState, doc, step, [], 1);
+
+    const finalState = editorState.apply(trackedTransaction);
+
+    // Expected result should handle the nested mark properly within the existing suggestion changes
+    const expected = testBuilders.doc(
+      testBuilders.paragraph(
+        "This ",
+        testBuilders.deletion({ id: 1 }, "is a test paragraph with"),
+        testBuilders.insertion({ id: 1 }, testBuilders.strong("is a ")),
+        testBuilders.insertion(
+          { id: 1 },
+          testBuilders.strong(testBuilders.em("test paragraph")),
+        ),
+        testBuilders.insertion({ id: 1 }, testBuilders.strong(" with")),
+        " content",
+      ),
+    );
+
+    assert(
+      eq(finalState.doc, expected),
+      `Expected ${finalState.doc} to match ${expected}`,
+    );
+  });
+
+  it("should handle left-side partial overlap of mark on existing suggestion", () => {
+    // Existing suggestion spans "test paragraph"
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "This is <a>a ",
+        testBuilders.deletion({ id: 1 }, "test paragraph"),
+        testBuilders.insertion(
+          { id: 1 },
+          testBuilders.strong("test para<b>graph"),
+        ),
+        " with content",
+      ),
+    ) as TaggedNode;
+
+    const editorState = EditorState.create({ doc });
+
+    // Add emphasis mark that partially overlaps from left: "a test para"
+    const originalTransaction = editorState.tr;
+    originalTransaction.addMark(
+      doc.tag["a"]!,
+      doc.tag["b"]!,
+      testBuilders.schema.marks.em.create(),
+    );
+    const step = originalTransaction.steps[0];
+    assert(step instanceof AddMarkStep, "Could not create AddMarkStep");
+
+    const trackedTransaction = editorState.tr;
+    trackAddMarkStep(trackedTransaction, editorState, doc, step, [], 2);
+
+    const finalState = editorState.apply(trackedTransaction);
+
+    // Expected: when there's overlap, marks are properly nested
+    const expected = testBuilders.doc(
+      testBuilders.paragraph(
+        "This is ",
+        testBuilders.deletion({ id: 1 }, "a test paragraph"),
+        testBuilders.insertion({ id: 1 }, testBuilders.em("a ")),
+        testBuilders.insertion(
+          { id: 1 },
+          testBuilders.em(testBuilders.strong("test para")),
+        ),
+        testBuilders.insertion({ id: 1 }, testBuilders.strong("graph")),
+        " with content",
+      ),
+    );
+
+    assert(
+      eq(finalState.doc, expected),
+      `Expected ${finalState.doc} to match ${expected}`,
+    );
+  });
+
+  it("should handle right-side partial overlap of mark on existing suggestion", () => {
+    // Existing suggestion spans "test paragraph"
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "This is a ",
+        testBuilders.deletion({ id: 1 }, "test paragraph"),
+        testBuilders.insertion(
+          { id: 1 },
+          testBuilders.strong("test para<a>graph"),
+        ),
+        "<b> with content",
+      ),
+    ) as TaggedNode;
+
+    const editorState = EditorState.create({ doc });
+
+    // Add emphasis mark that partially overlaps from right: "graph with"
+    const originalTransaction = editorState.tr;
+    originalTransaction.addMark(
+      doc.tag["a"]!,
+      doc.tag["b"]!,
+      testBuilders.schema.marks.em.create(),
+    );
+    const step = originalTransaction.steps[0];
+    assert(step instanceof AddMarkStep, "Could not create AddMarkStep");
+
+    const trackedTransaction = editorState.tr;
+    trackAddMarkStep(trackedTransaction, editorState, doc, step, [], 2);
+
+    const finalState = editorState.apply(trackedTransaction);
+
+    // Current behavior: only marks adjacent get inherited ID
+    const expected = testBuilders.doc(
+      testBuilders.paragraph(
+        "This is a ",
+        testBuilders.deletion({ id: 1 }, "test paragraph"),
+        testBuilders.insertion({ id: 1 }, testBuilders.strong("test para")),
+        testBuilders.insertion(
+          { id: 1 },
+          testBuilders.em(testBuilders.strong("graph")),
+        ),
+        " with content",
+      ),
+    );
+
+    assert(
+      eq(finalState.doc, expected),
+      `Expected ${finalState.doc} to match ${expected}`,
+    );
+  });
+
+  it("should handle existing suggestion completely inside new mark", () => {
+    // Small existing suggestion "test"
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "This is <a>a ",
+        testBuilders.deletion({ id: 1 }, "test"),
+        testBuilders.insertion({ id: 1 }, testBuilders.strong("test")),
+        " paragraph<b> with content",
+      ),
+    ) as TaggedNode;
+
+    const editorState = EditorState.create({ doc });
+
+    // Add emphasis mark that encompasses the suggestion: "a test paragraph"
+    const originalTransaction = editorState.tr;
+    originalTransaction.addMark(
+      doc.tag["a"]!,
+      doc.tag["b"]!,
+      testBuilders.schema.marks.em.create(),
+    );
+    const step = originalTransaction.steps[0];
+    assert(step instanceof AddMarkStep, "Could not create AddMarkStep");
+
+    const trackedTransaction = editorState.tr;
+    trackAddMarkStep(trackedTransaction, editorState, doc, step, [], 2);
+
+    const finalState = editorState.apply(trackedTransaction);
+
+    // Current behavior: uses new ID for entire range
+    const expected = testBuilders.doc(
+      testBuilders.paragraph(
+        "This is ",
+        testBuilders.deletion({ id: 2 }, "a test paragraph"),
+        testBuilders.insertion({ id: 2 }, testBuilders.em("a ")),
+        testBuilders.insertion(
+          { id: 2 },
+          testBuilders.em(testBuilders.strong("test")),
+        ),
+        testBuilders.insertion({ id: 2 }, testBuilders.em(" paragraph")),
+        " with content",
+      ),
+    );
+
+    assert(
+      eq(finalState.doc, expected),
+      `Expected ${finalState.doc} to match ${expected}`,
+    );
+  });
 });

--- a/src/addNodeMarkStep.ts
+++ b/src/addNodeMarkStep.ts
@@ -3,6 +3,7 @@ import { type EditorState, type Transaction } from "prosemirror-state";
 import { type AddNodeMarkStep, type Step } from "prosemirror-transform";
 
 import { rebasePos } from "./rebasePos.js";
+import { getSuggestionMarks } from "./utils.js";
 
 /**
  * Transform an add node mark step into its equivalent tracked steps.
@@ -18,12 +19,7 @@ export function trackAddNodeMarkStep(
   prevSteps: Step[],
   suggestionId: number,
 ) {
-  const { modification } = state.schema.marks;
-  if (!modification) {
-    throw new Error(
-      `Failed to apply modifications to node: schema does not contain modification mark. Did you forget to add it?`,
-    );
-  }
+  const { modification } = getSuggestionMarks(state.schema);
 
   const rebasedPos = rebasePos(step.pos, prevSteps, trackedTransaction.steps);
   const $pos = trackedTransaction.doc.resolve(rebasedPos);

--- a/src/attrStep.ts
+++ b/src/attrStep.ts
@@ -3,6 +3,7 @@ import { type EditorState, type Transaction } from "prosemirror-state";
 import { type AttrStep, type Step } from "prosemirror-transform";
 
 import { rebasePos } from "./rebasePos.js";
+import { getSuggestionMarks } from "./utils.js";
 
 /**
  * Transform an attr mark step into its equivalent tracked steps.
@@ -18,12 +19,7 @@ export function trackAttrStep(
   prevSteps: Step[],
   suggestionId: number,
 ) {
-  const { modification } = state.schema.marks;
-  if (!modification) {
-    throw new Error(
-      `Failed to apply modifications to node: schema does not contain modification mark. Did you forget to add it?`,
-    );
-  }
+  const { modification } = getSuggestionMarks(state.schema);
 
   const rebasedPos = rebasePos(step.pos, prevSteps, trackedTransaction.steps);
   const $pos = trackedTransaction.doc.resolve(rebasedPos);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -15,6 +15,7 @@ import { type EditorView } from "prosemirror-view";
 
 import { findSuggestionMarkEnd } from "./findSuggestionMarkEnd.js";
 import { suggestChangesKey } from "./plugin.js";
+import { getSuggestionMarks } from "./utils.js";
 
 /**
  * Given a node and a transform, add a set of steps to the
@@ -86,9 +87,8 @@ function applySuggestionsToTransform(
 }
 
 function revertModifications(node: Node, pos: number, tr: Transform) {
-  const existingMods = node.marks.filter(
-    (mark) => mark.type === node.type.schema.marks["modification"],
-  );
+  const { modification } = getSuggestionMarks(node.type.schema);
+  const existingMods = node.marks.filter((mark) => mark.type === modification);
   for (const mod of existingMods) {
     if (
       mod.attrs["type"] === "attr" &&
@@ -129,12 +129,7 @@ function applyModificationsToTransform(
   dir: number,
   suggestionId?: number,
 ) {
-  const { modification } = node.type.schema.marks;
-  if (!modification) {
-    throw new Error(
-      `Failed to apply modifications to node: schema does not contain modification mark. Did you forget to add it?`,
-    );
-  }
+  const { modification } = getSuggestionMarks(node.type.schema);
 
   const modificationIsInSet =
     suggestionId === undefined
@@ -176,21 +171,38 @@ function applyModificationsToTransform(
   });
 }
 
-function applySuggestionsToNode(node: Node) {
-  const { deletion, insertion } = node.type.schema.marks;
-  if (!deletion) {
-    throw new Error(
-      `Failed to apply tracked changes to node: schema does not contain deletion mark. Did you forget to add it?`,
-    );
+function applyTextNodeSuggestions(node: Node) {
+  if (!node.isText || !node.text) {
+    return null;
   }
-  if (!insertion) {
-    throw new Error(
-      `Failed to apply tracked changes to node: schema does not contain insertion mark. Did you forget to add it?`,
-    );
-  }
+  const { deletion, insertion } = getSuggestionMarks(node.type.schema);
 
   if (deletion.isInSet(node.marks)) {
     return null;
+  }
+
+  // Remove insertion marks from the text node
+  const newMarks = node.marks.filter((mark) => mark.type !== insertion);
+
+  // If it's a zero-width space with insertion mark, remove it
+  if (node.text === "\u200B" && insertion.isInSet(node.marks)) {
+    return null;
+  }
+
+  // Return a new text node with the filtered marks
+  return node.type.schema.text(node.text, newMarks);
+}
+
+function applySuggestionsToNode(node: Node) {
+  const { deletion, insertion } = getSuggestionMarks(node.type.schema);
+
+  if (deletion.isInSet(node.marks)) {
+    return null;
+  }
+
+  // Handle inline nodes (text nodes) without creating a Transform
+  if (node.isText) {
+    return applyTextNodeSuggestions(node);
   }
 
   const transform = new Transform(node);
@@ -219,17 +231,7 @@ export function applySuggestions(
   state: EditorState,
   dispatch?: EditorView["dispatch"],
 ) {
-  const { deletion, insertion } = state.schema.marks;
-  if (!deletion) {
-    throw new Error(
-      `Failed to apply tracked changes to node: schema does not contain deletion mark. Did you forget to add it?`,
-    );
-  }
-  if (!insertion) {
-    throw new Error(
-      `Failed to apply tracked changes to node: schema does not contain insertion mark. Did you forget to add it?`,
-    );
-  }
+  const { deletion, insertion } = getSuggestionMarks(state.schema);
 
   const tr = state.tr;
   applySuggestionsToTransform(state.doc, tr, insertion, deletion);
@@ -248,17 +250,7 @@ export function applySuggestions(
  */
 export function applySuggestion(suggestionId: number): Command {
   return (state, dispatch) => {
-    const { deletion, insertion } = state.schema.marks;
-    if (!deletion) {
-      throw new Error(
-        `Failed to apply tracked changes to node: schema does not contain deletion mark. Did you forget to add it?`,
-      );
-    }
-    if (!insertion) {
-      throw new Error(
-        `Failed to apply tracked changes to node: schema does not contain insertion mark. Did you forget to add it?`,
-      );
-    }
+    const { deletion, insertion } = getSuggestionMarks(state.schema);
 
     const tr = state.tr;
     applySuggestionsToTransform(
@@ -287,17 +279,7 @@ export function revertSuggestions(
   state: EditorState,
   dispatch?: EditorView["dispatch"],
 ) {
-  const { deletion, insertion } = state.schema.marks;
-  if (!deletion) {
-    throw new Error(
-      `Failed to apply tracked changes to node: schema does not contain deletion mark. Did you forget to add it?`,
-    );
-  }
-  if (!insertion) {
-    throw new Error(
-      `Failed to apply tracked changes to node: schema does not contain insertion mark. Did you forget to add it?`,
-    );
-  }
+  const { deletion, insertion } = getSuggestionMarks(state.schema);
   const tr = state.tr;
   applySuggestionsToTransform(state.doc, tr, deletion, insertion);
   applyModificationsToTransform(tr.doc, tr, -1);
@@ -315,17 +297,7 @@ export function revertSuggestions(
  */
 export function revertSuggestion(suggestionId: number): Command {
   return (state, dispatch) => {
-    const { deletion, insertion } = state.schema.marks;
-    if (!deletion) {
-      throw new Error(
-        `Failed to apply tracked changes to node: schema does not contain deletion mark. Did you forget to add it?`,
-      );
-    }
-    if (!insertion) {
-      throw new Error(
-        `Failed to apply tracked changes to node: schema does not contain insertion mark. Did you forget to add it?`,
-      );
-    }
+    const { deletion, insertion } = getSuggestionMarks(state.schema);
 
     const tr = state.tr;
     applySuggestionsToTransform(
@@ -348,22 +320,9 @@ export function revertSuggestion(suggestionId: number): Command {
  */
 export function selectSuggestion(suggestionId: number): Command {
   return (state, dispatch) => {
-    const { deletion, insertion, modification } = state.schema.marks;
-    if (!deletion) {
-      throw new Error(
-        `Failed to apply tracked changes to node: schema does not contain deletion mark. Did you forget to add it?`,
-      );
-    }
-    if (!insertion) {
-      throw new Error(
-        `Failed to apply tracked changes to node: schema does not contain insertion mark. Did you forget to add it?`,
-      );
-    }
-    if (!modification) {
-      throw new Error(
-        `Failed to apply tracked changes to node: schema does not contain modification mark. Did you forget to add it?`,
-      );
-    }
+    const { deletion, insertion, modification } = getSuggestionMarks(
+      state.schema,
+    );
 
     let changeStart = null as number | null;
     let changeEnd = null as number | null;

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -5,6 +5,7 @@ import {
   DecorationSet,
   type DecorationSource,
 } from "prosemirror-view";
+import { getSuggestionMarks } from "./utils.js";
 
 function pilcrow() {
   const span = document.createElement("span");
@@ -13,17 +14,7 @@ function pilcrow() {
 }
 
 export function getSuggestionDecorations(state: EditorState): DecorationSource {
-  const { deletion, insertion } = state.schema.marks;
-  if (!deletion) {
-    throw new Error(
-      `Failed to apply tracked changes to node: schema does not contain deletion mark. Did you forget to add it?`,
-    );
-  }
-  if (!insertion) {
-    throw new Error(
-      `Failed to apply tracked changes to node: schema does not contain insertion mark. Did you forget to add it?`,
-    );
-  }
+  const { deletion, insertion } = getSuggestionMarks(state.schema);
 
   const changeDecorations: Decoration[] = [];
   let lastParentNode: Node | null = null;

--- a/src/removeNodeMarkStep.ts
+++ b/src/removeNodeMarkStep.ts
@@ -3,6 +3,7 @@ import { type EditorState, type Transaction } from "prosemirror-state";
 import { type RemoveNodeMarkStep, type Step } from "prosemirror-transform";
 
 import { rebasePos } from "./rebasePos.js";
+import { getSuggestionMarks } from "./utils.js";
 
 /**
  * Transform a remove node mark step into its equivalent tracked steps.
@@ -18,12 +19,7 @@ export function suggestRemoveNodeMarkStep(
   prevSteps: Step[],
   suggestionId: number,
 ) {
-  const { modification } = state.schema.marks;
-  if (!modification) {
-    throw new Error(
-      `Failed to apply modifications to node: schema does not contain modification mark. Did you forget to add it?`,
-    );
-  }
+  const { modification } = getSuggestionMarks(state.schema);
 
   const rebasedPos = rebasePos(step.pos, prevSteps, trackedTransaction.steps);
   const $pos = trackedTransaction.doc.resolve(rebasedPos);

--- a/src/replaceAroundStep.ts
+++ b/src/replaceAroundStep.ts
@@ -16,6 +16,7 @@ import { applySuggestionsToSlice } from "./commands.js";
 import { rebasePos } from "./rebasePos.js";
 import { suggestRemoveNodeMarkStep } from "./removeNodeMarkStep.js";
 import { suggestReplaceStep } from "./replaceStep.js";
+import { getSuggestionMarks } from "./utils.js";
 
 /**
  * This detects and handles changes from `setNodeMarkup` so that these are tracked as a modification
@@ -37,12 +38,7 @@ function suggestSetNodeMarkup(
     step.gapFrom === step.from + 1 &&
     (step as ReplaceAroundStep & { structure: boolean }).structure
   ) {
-    const { modification } = state.schema.marks;
-    if (!modification) {
-      throw new Error(
-        `Failed to apply modifications to node: schema does not contain modification mark. Did you forget to add it?`,
-      );
-    }
+    const { modification } = getSuggestionMarks(state.schema);
 
     const newNode = step.slice.content.firstChild;
     let from = rebasePos(step.from, prevSteps, trackedTransaction.steps);

--- a/src/replaceStep.ts
+++ b/src/replaceStep.ts
@@ -8,6 +8,7 @@ import { type ReplaceStep, type Step } from "prosemirror-transform";
 
 import { findSuggestionMarkEnd } from "./findSuggestionMarkEnd.js";
 import { rebasePos } from "./rebasePos.js";
+import { getSuggestionMarks } from "./utils.js";
 
 /**
  * Transform a replace step into its equivalent tracked steps.
@@ -47,17 +48,7 @@ export function suggestReplaceStep(
   prevSteps: Step[],
   suggestionId: number,
 ) {
-  const { deletion, insertion } = state.schema.marks;
-  if (!deletion) {
-    throw new Error(
-      `Failed to apply tracked changes to node: schema does not contain deletion mark. Did you forget to add it?`,
-    );
-  }
-  if (!insertion) {
-    throw new Error(
-      `Failed to apply tracked changes to node: schema does not contain insertion mark. Did you forget to add it?`,
-    );
-  }
+  const { deletion, insertion } = getSuggestionMarks(state.schema);
 
   // Check for insertion and deletion marks directly
   // adjacent to this step's boundaries. If they exist,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,35 @@
+import { type MarkType, type Schema } from "prosemirror-model";
+
+export interface SuggestionMarks {
+  insertion: MarkType;
+  deletion: MarkType;
+  modification: MarkType;
+}
+
+/**
+ * Get the suggestion mark types from a schema, with proper error handling.
+ * Throws an error if any of the required marks are not found.
+ */
+export function getSuggestionMarks(schema: Schema): SuggestionMarks {
+  const { insertion, deletion, modification } = schema.marks;
+
+  if (!insertion) {
+    throw new Error(
+      "Failed to find insertion mark in schema. Did you forget to add it?",
+    );
+  }
+
+  if (!deletion) {
+    throw new Error(
+      "Failed to find deletion mark in schema. Did you forget to add it?",
+    );
+  }
+
+  if (!modification) {
+    throw new Error(
+      "Failed to find modification mark in schema. Did you forget to add it?",
+    );
+  }
+
+  return { insertion, deletion, modification };
+}

--- a/src/withSuggestChanges.ts
+++ b/src/withSuggestChanges.ts
@@ -20,6 +20,7 @@ import { suggestReplaceAroundStep } from "./replaceAroundStep.js";
 import { suggestReplaceStep } from "./replaceStep.js";
 import { type EditorView } from "prosemirror-view";
 import { isSuggestChangesEnabled, suggestChangesKey } from "./plugin.js";
+import { getSuggestionMarks } from "./utils.js";
 
 type StepHandler<S extends Step> = (
   trackedTransaction: Transaction,
@@ -51,9 +52,6 @@ function getStepHandler<S extends Step>(step: S): StepHandler<S> {
   }
   if (step instanceof AttrStep) {
     return trackAttrStep as unknown as StepHandler<S>;
-  }
-  if (step instanceof AddNodeMarkStep) {
-    return trackAddNodeMarkStep as unknown as StepHandler<S>;
   }
 
   // Default handler — simply rebase the step onto the
@@ -98,22 +96,10 @@ export function transformToSuggestionTransaction(
   originalTransaction: Transaction,
   state: EditorState,
 ) {
-  const { deletion, insertion, modification } = state.schema.marks;
-  if (!deletion) {
-    throw new Error(
-      `Failed to transform to suggestion: schema does not contain deletion mark. Did you forget to add it?`,
-    );
-  }
-  if (!insertion) {
-    throw new Error(
-      `Failed to transform to suggestion: schema does not contain insertion mark. Did you forget to add it?`,
-    );
-  }
-  if (!modification) {
-    throw new Error(
-      `Failed to transform to suggestion: schema does not contain modification mark. Did you forget to add it?`,
-    );
-  }
+  // Validate that all required marks exist in the schema
+  const { deletion, insertion, modification } = getSuggestionMarks(
+    state.schema,
+  );
 
   // Find the highest change id in the document so far,
   // and use that as the starting point for new changes


### PR DESCRIPTION
Based off https://github.com/handlewithcarecollective/prosemirror-suggest-changes/pull/18
Inside an existing suggestion if there was a Mark already a transaction was sent to add another Mark inside that there was a nodeSize error. 
https://discuss.prosemirror.net/t/new-transform-with-leaf-text-node/8488/2 helps to understand the issue.