### PR TITLE
fix empty paragraphs appearing on block level deletions

### DIFF
--- a/src/__tests__/withSuggestChanges.test.ts
+++ b/src/__tests__/withSuggestChanges.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { eq } from "prosemirror-test-builder";
 import { type SuggestionId } from "../generateId.js";
-import { EditorState } from "prosemirror-state";
+import { EditorState, TextSelection } from "prosemirror-state";
 import { Fragment, Slice } from "prosemirror-model";
 import { type ReplaceStep, replaceStep } from "prosemirror-transform";
 import { assert, describe, expect, it } from "vitest";
@@ -206,6 +206,45 @@ describe("withSuggestChanges", () => {
     assert(
       eq(state.doc, expected),
       `Expected ${state.doc} to match ${expected}`,
+    );
+  });
+
+  it("should not create empty paragraphs on cross-block deletions", () => {
+    const doc = testBuilders.doc(
+      testBuilders.orderedList(
+        testBuilders.listItem(testBuilders.paragraph("<a>AAA")),
+      ),
+      testBuilders.paragraph("B<b>BB"),
+    ) as TaggedNode;
+
+    const editorState = EditorState.create({
+      doc,
+      selection: TextSelection.create(doc, doc.tag["a"]!, doc.tag["b"]!),
+    });
+
+    const originalTransaction = editorState.tr;
+    originalTransaction.deleteSelection();
+
+    const suggestedTr = transformToSuggestionTransaction(
+      originalTransaction,
+      editorState,
+    );
+    const newState = editorState.apply(suggestedTr);
+
+    // The deletion should only mark "AAA" and "B" as deleted.
+    // "BB" should remain unmarked, with no extra empty paragraphs.
+    const expected = testBuilders.doc(
+      testBuilders.orderedList(
+        testBuilders.listItem(
+          testBuilders.paragraph(testBuilders.deletion({ id: 1 }, "AAA")),
+        ),
+      ),
+      testBuilders.paragraph(testBuilders.deletion({ id: 1 }, "B"), "BB"),
+    );
+
+    assert(
+      eq(newState.doc, expected),
+      `Expected ${newState.doc} to match ${expected}`,
     );
   });
 

--- a/src/__tests__/withSuggestChanges.test.ts
+++ b/src/__tests__/withSuggestChanges.test.ts
@@ -219,7 +219,7 @@ describe("withSuggestChanges", () => {
 
     const editorState = EditorState.create({
       doc,
-      selection: TextSelection.create(doc, doc.tag["a"]!, doc.tag["b"]!),
+      selection: TextSelection.create(doc, doc.tag["a"]!, doc.tag["b"]),
     });
 
     const originalTransaction = editorState.tr;

--- a/src/replaceStep.ts
+++ b/src/replaceStep.ts
@@ -1,4 +1,4 @@
-import { type Node } from "prosemirror-model";
+  import { type Node } from "prosemirror-model";
 import {
   type EditorState,
   TextSelection,
@@ -249,8 +249,15 @@ export function suggestReplaceStep(
     }
   }
 
-  // Handle insertions
-  if (step.slice.content.size) {
+  // Handle insertions — skip when the slice is purely structural
+  // (e.g. cross-block deletion joining tokens with no text content)
+  const hasTextInSlice = !!step.slice.content.textBetween(
+    0,
+    step.slice.content.size,
+    "",
+    "",
+  );
+  if (step.slice.content.size && (hasTextInSlice || step.from === step.to)) {
     const $to = trackedTransaction.doc.resolve(stepTo);
 
     // Don't allow inserting content within an existing deletion


### PR DESCRIPTION
Cross-block deletions (e.g. selecting across list items + paragraph and deleting) produced extra empty paragraphs with ZWS insertion marks. This happened because suggestReplaceStep treated purely structural joining slices (empty paragraph tokens with no text) as content to insert.


The fix skips the insertion path when the slice has no text content and there's a deletion range (from !== to), so structural joining tokens are no longer materialized as visible empty paragraphs.